### PR TITLE
Configure vendor-specific USB-NICs to LinkLocal+DHCPv4 address automatically.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3543,7 +3543,8 @@ INSTALL_DIRS += \
 dist_network_DATA = \
 	network/99-default.link \
 	network/80-container-host0.network \
-	network/80-container-ve.network
+	network/80-container-ve.network \
+	network/80-vendor-usb-nics.network
 
 dist_udevrules_DATA += \
 	rules/50-udev-default.rules \

--- a/network/80-vendor-usb-nics.network
+++ b/network/80-vendor-usb-nics.network
@@ -1,0 +1,14 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Match]
+AutoLL=autoip
+
+[Network]
+# By default link local address for USB-NICs.
+LinkLocalAddressing=ipv4
+DHCP=ipv4

--- a/src/libsystemd-network/network-internal.c
+++ b/src/libsystemd-network/network-internal.c
@@ -91,6 +91,7 @@ bool net_match_config(const struct ether_addr *match_mac,
                       char * const *match_drivers,
                       char * const *match_types,
                       char * const *match_names,
+                      char * const *match_autoll,
                       Condition *match_host,
                       Condition *match_virt,
                       Condition *match_kernel,
@@ -100,7 +101,8 @@ bool net_match_config(const struct ether_addr *match_mac,
                       const char *dev_parent_driver,
                       const char *dev_driver,
                       const char *dev_type,
-                      const char *dev_name) {
+                      const char *dev_name,
+                      const char *dev_autoll) {
 
         if (match_host && !condition_test(match_host))
                 return false;
@@ -133,6 +135,10 @@ bool net_match_config(const struct ether_addr *match_mac,
             (!dev_name || !strv_fnmatch_or_empty(match_names, dev_name, 0)))
                 return false;
 
+        if (!strv_isempty(match_autoll) &&
+            (!dev_autoll || !strv_fnmatch_or_empty(match_autoll, dev_autoll, 0)))
+                return false;
+        
         return true;
 }
 
@@ -291,6 +297,42 @@ int config_parse_ifalias(const char *unit,
                 n = NULL;
         } else
                 *s = NULL;
+
+        return 0;
+}
+
+int config_parse_autoll(const char *unit,
+                        const char *filename,
+                        unsigned line,
+                        const char *section,
+                        unsigned section_line,
+                        const char *lvalue,
+                        int ltype,
+                        const char *rvalue,
+                        void *data,
+                        void *userdata) {
+
+        char ***s = data;
+        char *n = NULL;
+        int r;
+
+        assert(filename);
+        assert(lvalue);
+        assert(rvalue);
+        assert(data);
+
+        n = strdup(rvalue);
+        if (!n)
+                return log_oom();
+
+        if (!ascii_is_valid(n) || strlen(n) > AUTOLLSZ) {
+                log_syntax(unit, LOG_ERR, filename, line, 0, "autoll string is not ASCII clean or is too long, ignoring assignment: %s", rvalue);
+                return 0;
+        }
+
+        r = strv_consume(s, n);
+        if (r < 0)
+                return log_oom();
 
         return 0;
 }

--- a/src/libsystemd-network/network-internal.h
+++ b/src/libsystemd-network/network-internal.h
@@ -34,6 +34,7 @@ bool net_match_config(const struct ether_addr *match_mac,
                       char * const *match_driver,
                       char * const *match_type,
                       char * const *match_name,
+                      char * const *match_autoll,
                       Condition *match_host,
                       Condition *match_virt,
                       Condition *match_kernel,
@@ -43,7 +44,8 @@ bool net_match_config(const struct ether_addr *match_mac,
                       const char *dev_parent_driver,
                       const char *dev_driver,
                       const char *dev_type,
-                      const char *dev_name);
+                      const char *dev_name,
+                      const char *dev_autoll);
 
 int config_parse_net_condition(const char *unit, const char *filename, unsigned line,
                                const char *section, unsigned section_line, const char *lvalue,
@@ -64,6 +66,10 @@ int config_parse_ifnames(const char *unit, const char *filename, unsigned line,
 int config_parse_ifalias(const char *unit, const char *filename, unsigned line,
                          const char *section, unsigned section_line, const char *lvalue,
                          int ltype, const char *rvalue, void *data, void *userdata);
+                         
+int config_parse_autoll(const char *unit, const char *filename, unsigned line,
+                        const char *section, unsigned section_line, const char *lvalue,
+                        int ltype, const char *rvalue, void *data, void *userdata);
 
 int net_get_unique_predictable_data(struct udev_device *device, uint64_t *result);
 const char *net_get_name(struct udev_device *device);

--- a/src/libsystemd-network/network-internal.h
+++ b/src/libsystemd-network/network-internal.h
@@ -26,6 +26,9 @@
 #include "condition.h"
 #include "udev.h"
 
+/* Keeping the size of AutoLL parameter to string length of "autoip" */
+#define AUTOLLSZ 6
+
 bool net_match_config(const struct ether_addr *match_mac,
                       char * const *match_path,
                       char * const *match_driver,

--- a/src/libudev/libudev-device.c
+++ b/src/libudev/libudev-device.c
@@ -187,6 +187,28 @@ _public_ const char *udev_device_get_subsystem(struct udev_device *udev_device)
 }
 
 /**
+ * udev_device_get_autoll:
+ * @udev_device: udev device
+ *
+ * Retrieve the autoll string of the udev device.
+ *
+ * Returns: the AutoLL property of the udev device, or #NULL if it can not be determined
+ **/
+_public_ const char *udev_device_get_autoll(struct udev_device *udev_device)
+{
+        const char *autoll = NULL;
+
+        assert_return_errno(udev_device, NULL, EINVAL);
+
+        autoll = udev_device_get_property_value(udev_device, "ID_NET_AUTO_LL");
+        if (!autoll) {
+                return NULL;
+        }
+
+        return autoll;
+}
+
+/**
  * udev_device_get_property_value:
  * @udev_device: udev device
  * @key: property name

--- a/src/libudev/libudev.h
+++ b/src/libudev/libudev.h
@@ -101,6 +101,7 @@ struct udev_list_entry *udev_device_get_tags_list_entry(struct udev_device *udev
 struct udev_list_entry *udev_device_get_sysattr_list_entry(struct udev_device *udev_device);
 const char *udev_device_get_property_value(struct udev_device *udev_device, const char *key);
 const char *udev_device_get_driver(struct udev_device *udev_device);
+const char *udev_device_get_autoll(struct udev_device *udev_device);
 dev_t udev_device_get_devnum(struct udev_device *udev_device);
 const char *udev_device_get_action(struct udev_device *udev_device);
 unsigned long long int udev_device_get_seqnum(struct udev_device *udev_device);

--- a/src/network/networkd-netdev.c
+++ b/src/network/networkd-netdev.c
@@ -611,10 +611,10 @@ static int netdev_load_one(Manager *manager, const char *filename) {
                 return -errno;
 
         /* skip out early if configuration does not match the environment */
-        if (net_match_config(NULL, NULL, NULL, NULL, NULL,
+        if (net_match_config(NULL, NULL, NULL, NULL, NULL, NULL,
                              netdev_raw->match_host, netdev_raw->match_virt,
                              netdev_raw->match_kernel, netdev_raw->match_arch,
-                             NULL, NULL, NULL, NULL, NULL, NULL) <= 0)
+                             NULL, NULL, NULL, NULL, NULL, NULL, NULL) <= 0)
                 return 0;
 
         if (!NETDEV_VTABLE(netdev_raw)) {

--- a/src/network/networkd-network-bus.c
+++ b/src/network/networkd-network-bus.c
@@ -67,6 +67,7 @@ const sd_bus_vtable network_vtable[] = {
         SD_BUS_PROPERTY("MatchDriver", "as", NULL, offsetof(Network, match_driver), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("MatchType", "as", NULL, offsetof(Network, match_type), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("MatchName", "as", NULL, offsetof(Network, match_name), SD_BUS_VTABLE_PROPERTY_CONST),
+        SD_BUS_PROPERTY("MatchAutoLL", "as", NULL, offsetof(Network, match_autoll), SD_BUS_VTABLE_PROPERTY_CONST),
 
         SD_BUS_VTABLE_END
 };

--- a/src/network/networkd-network-gperf.gperf
+++ b/src/network/networkd-network-gperf.gperf
@@ -20,6 +20,7 @@ Match.Path,                             config_parse_strv,                      
 Match.Driver,                           config_parse_strv,                              0,                             offsetof(Network, match_driver)
 Match.Type,                             config_parse_strv,                              0,                             offsetof(Network, match_type)
 Match.Name,                             config_parse_ifnames,                           0,                             offsetof(Network, match_name)
+Match.AutoLL,                           config_parse_autoll,                            0,                             offsetof(Network, match_autoll)
 Match.Host,                             config_parse_net_condition,                     CONDITION_HOST,                offsetof(Network, match_host)
 Match.Virtualization,                   config_parse_net_condition,                     CONDITION_VIRTUALIZATION,      offsetof(Network, match_virt)
 Match.KernelCommandLine,                config_parse_net_condition,                     CONDITION_KERNEL_COMMAND_LINE, offsetof(Network, match_kernel)

--- a/src/network/networkd-network.c
+++ b/src/network/networkd-network.c
@@ -221,6 +221,7 @@ void network_free(Network *network) {
         strv_free(network->match_driver);
         strv_free(network->match_type);
         strv_free(network->match_name);
+        strv_free(network->match_autoll);
 
         free(network->description);
         free(network->dhcp_vendor_class_identifier);
@@ -299,7 +300,7 @@ int network_get(Manager *manager, struct udev_device *device,
                 Network **ret) {
         Network *network;
         struct udev_device *parent;
-        const char *path = NULL, *parent_driver = NULL, *driver = NULL, *devtype = NULL;
+        const char *path = NULL, *parent_driver = NULL, *driver = NULL, *devtype = NULL, *autoll = NULL;
 
         assert(manager);
         assert(ret);
@@ -314,16 +315,18 @@ int network_get(Manager *manager, struct udev_device *device,
                 driver = udev_device_get_property_value(device, "ID_NET_DRIVER");
 
                 devtype = udev_device_get_devtype(device);
+                
+                autoll = udev_device_get_property_value(device, "ID_NET_AUTO_LL");
         }
 
         LIST_FOREACH(networks, network, manager->networks) {
                 if (net_match_config(network->match_mac, network->match_path,
                                      network->match_driver, network->match_type,
-                                     network->match_name, network->match_host,
-                                     network->match_virt, network->match_kernel,
-                                     network->match_arch,
+                                     network->match_name, network->match_autoll,
+                                     network->match_host, network->match_virt,
+                                     network->match_kernel, network->match_arch,
                                      address, path, parent_driver, driver,
-                                     devtype, ifname)) {
+                                     devtype, ifname, autoll)) {
                         if (network->match_name && device) {
                                 const char *attr;
                                 uint8_t name_assign_type = NET_NAME_UNKNOWN;

--- a/src/network/networkd-network.h
+++ b/src/network/networkd-network.h
@@ -62,6 +62,7 @@ struct Network {
         char **match_driver;
         char **match_type;
         char **match_name;
+        char **match_autoll;
 
         Condition *match_host;
         Condition *match_virt;

--- a/src/udev/net/link-config.c
+++ b/src/udev/net/link-config.c
@@ -256,14 +256,16 @@ int link_config_get(link_config_ctx *ctx, struct udev_device *device,
                 attr_value = udev_device_get_sysattr_value(device, "address");
 
                 if (net_match_config(link->match_mac, link->match_path, link->match_driver,
-                                     link->match_type, link->match_name, link->match_host,
-                                     link->match_virt, link->match_kernel, link->match_arch,
+                                     link->match_type, link->match_name, link->match_autoll,
+                                     link->match_host, link->match_virt, link->match_kernel,
+                                     link->match_arch,
                                      attr_value ? ether_aton(attr_value) : NULL,
                                      udev_device_get_property_value(device, "ID_PATH"),
                                      udev_device_get_driver(udev_device_get_parent(device)),
                                      udev_device_get_property_value(device, "ID_NET_DRIVER"),
                                      udev_device_get_devtype(device),
-                                     udev_device_get_sysname(device))) {
+                                     udev_device_get_sysname(device),
+                                     udev_device_get_property_value(device, "ID_NET_AUTO_LL"))) {
                         if (link->match_name) {
                                 unsigned char name_assign_type = NET_NAME_UNKNOWN;
 

--- a/src/udev/net/link-config.h
+++ b/src/udev/net/link-config.h
@@ -57,6 +57,7 @@ struct link_config {
         char **match_driver;
         char **match_type;
         char **match_name;
+        char **match_autoll;
         Condition *match_host;
         Condition *match_virt;
         Condition *match_kernel;

--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -572,6 +572,9 @@ static int builtin_net_id(struct udev_device *dev, int argc, char *argv[], bool 
         err = names_usb(dev, &names);
         if (err >= 0 && names.type == NET_USB) {
                 char str[IFNAMSIZ];
+                
+                /* Add "ID_NET_AUTO_LL" only for USB-NICs */
+                udev_builtin_add_property(dev, test, "ID_NET_AUTO_LL", NULL);                
 
                 if (names.pci_path[0])
                         if (snprintf(str, sizeof(str), "%s%s%s", prefix, names.pci_path, names.usb_ports) < (int)sizeof(str))


### PR DESCRIPTION
This patch is to configure vendor-specific usb-nics automatically to Link local IPv4 address with DHCP.

A new generic network file 80-vendor-usb-nics.network will be responsible to achieve this.
Create a new udev property for usb-nics named 'ID_NET_AUTO_LL' which has to be set to 'autoip' using hwdb entries for the particular usb-nic.
A new Match field named 'AutoLL' is created which will check whether the 'ID_NET_AUTO_LL' property is set to 'autoip'. If a match succeeds, then the interface is configured to LinkLocal+DHCPv4 address.

Suitable changes are made to Network structure and link_config structure to add the new attribute, autoll.
config_parse_autoll() is used to parse the AutoLL property from the network file. During this parsing, few sanity checks like string length and ascii checks are done.
udev_device_get_autoll() is used to get the value of udev property  'ID_NET_AUTO_LL' from udev-db.

